### PR TITLE
Allow Crystal 1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,6 @@ version: 0.1.0
 authors:
   - Joe Eli McIlvain <joe.eli.mac@gmail.com>
 
-crystal: 0.26.1
+crystal: '>= 0.35.1'
 
 license: MPLv2


### PR DESCRIPTION
Small bump to the Crystal target version in shard.yml to allow for use on 1.0.0 and the latest `shards`. If merged, probably worth tagging as a new version too.