### PR TITLE
Expose MatchError#offset

### DIFF
--- a/spec/pegmatite_spec.cr
+++ b/spec/pegmatite_spec.cr
@@ -156,4 +156,16 @@ describe Pegmatite do
       Pegmatite.tokenize(Fixtures::JSONGrammar, source)
     end
   end
+
+  describe Pegmatite::Pattern::MatchError do
+    it "provides the offset of where the parse error ocurred" do
+      source = "{\"hello\": \"uh oh"
+
+      begin
+        Pegmatite.tokenize(Fixtures::JSONGrammar, source)
+      rescue err : Pegmatite::Pattern::MatchError
+        err.offset.should eq(16)
+      end
+    end
+  end
 end

--- a/src/pegmatite/pattern.cr
+++ b/src/pegmatite/pattern.cr
@@ -40,19 +40,21 @@ abstract class Pegmatite::Pattern
   # Higher-level methods may choose to represent errors as exceptions,
   # created in part by getting the description of the Pattern that failed.
   class MatchError < Exception
+    getter offset : Int32
+
     def initialize(source, fail : {Int32, Pattern})
-      offset, pattern = fail
+      @offset, pattern = fail
       description = pattern.description
 
-      line_start = (source.rindex("\n", [offset - 1, 0].max) || -1) + 1
-      line_finish = (source.index("\n", offset) || source.size)
+      line_start = (source.rindex("\n", [@offset - 1, 0].max) || -1) + 1
+      line_finish = (source.index("\n", @offset) || source.size)
 
       line = source[line_start...line_finish]
-      cursor = " " * (offset - line_start) + "^"
+      cursor = " " * (@offset - line_start) + "^"
 
       # TODO: Use pattern.description after reliably getting the right pattern.
       # TODO: Report source name/filename and line number too.
-      super("unexpected token at byte offset #{offset}:\n#{line}\n#{cursor}")
+      super("unexpected token at byte offset #{@offset}:\n#{line}\n#{cursor}")
     end
   end
 


### PR DESCRIPTION
This will allow Pegmatite users to surface more information about where parsing fails.

In particular, we want this to continue the work started in https://github.com/jemc/mare/pull/67