### PR TITLE
Add 'max' to repeat; also add 'repeat_exactly'

### DIFF
--- a/src/pegmatite/dsl.cr
+++ b/src/pegmatite/dsl.cr
@@ -79,8 +79,12 @@ class Pegmatite::DSL
       Pattern::Not.new(self)
     end
 
-    def repeat(min = 0)
-      Pattern::Repeat.new(self, min)
+    def repeat(min = 0, max = nil)
+      Pattern::Repeat.new(self, min, max)
+    end
+
+    def repeat_exactly(times)
+      repeat(times, times)
     end
 
     def maybe

--- a/src/pegmatite/pattern/repeat.cr
+++ b/src/pegmatite/pattern/repeat.cr
@@ -16,9 +16,9 @@ module Pegmatite
       @child.inspect(io)
       io << ".repeat("
       @min.inspect(io)
-      if max = @max
+      if @max < Int32::MAX
         io << "-"
-        max.inspect(io)
+        @max.inspect(io)
       end
       io << ")"
     end
@@ -28,7 +28,7 @@ module Pegmatite
     end
 
     def description
-      if max = @max
+      if @max < Int32::MAX
         "#{@min} to #{@max} occurrences of #{@child.description}"
       else
         "#{@min} or more occurrences of #{@child.description}"


### PR DESCRIPTION
Pretty simple. This just adds an optional `max` value to the `repeat` DSL item which does exactly what it says. Also adds a `repeat_exactly` item to the DSL which wraps `repeat` and sets the min and max to the same value.